### PR TITLE
Channel modified to send the the telemetry to Application Insights.

### DIFF
--- a/Glimpse.ApplicationInsights.Sample/ApplicationInsights.config
+++ b/Glimpse.ApplicationInsights.Sample/ApplicationInsights.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
-  <InstrumentationKey>Foo</InstrumentationKey>
-  <TelemetryChannel Type="Glimpse.ApplicationInsights.GlimpseTelemetryChannel, Glimpse.ApplicationInsights"/>
+  <InstrumentationKey>00000000-0000-0000-0000-000000000000</InstrumentationKey>
+  <TelemetryChannel Type="Glimpse.ApplicationInsights.GlimpseTelemetryChannel, Glimpse.ApplicationInsights">
+    <Channel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
+  </TelemetryChannel>
   <TelemetryModules>
     <Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector"/>
     <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">

--- a/Glimpse.ApplicationInsights.Sample/ApplicationInsights.config
+++ b/Glimpse.ApplicationInsights.Sample/ApplicationInsights.config
@@ -2,7 +2,7 @@
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
   <InstrumentationKey>00000000-0000-0000-0000-000000000000</InstrumentationKey>
   <TelemetryChannel Type="Glimpse.ApplicationInsights.GlimpseTelemetryChannel, Glimpse.ApplicationInsights">
-    <Channel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
+    <ApplicationInsightsChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
   </TelemetryChannel>
   <TelemetryModules>
     <Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector"/>

--- a/Glimpse.ApplicationInsights.Sample/packages.config
+++ b/Glimpse.ApplicationInsights.Sample/packages.config
@@ -41,6 +41,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
   <package id="System.Data.Entity.Repository" version="2.0.0.1" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />

--- a/Glimpse.ApplicationInsights/Glimpse.ApplicationInsights.csproj
+++ b/Glimpse.ApplicationInsights/Glimpse.ApplicationInsights.csproj
@@ -83,6 +83,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/Glimpse.ApplicationInsights/Glimpse.ApplicationInsights.csproj
+++ b/Glimpse.ApplicationInsights/Glimpse.ApplicationInsights.csproj
@@ -88,8 +88,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <Import Project="..\.nuget\NuGet.targets" Condition="Exists('..\.nuget\NuGet.targets')" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Glimpse.ApplicationInsights/Glimpse.ApplicationInsights.csproj
+++ b/Glimpse.ApplicationInsights/Glimpse.ApplicationInsights.csproj
@@ -88,7 +88,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <Import Project="..\.nuget\NuGet.targets" Condition="Exists('..\.nuget\NuGet.targets')" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Glimpse.ApplicationInsights/GlimpseTelemetryChannel.cs
+++ b/Glimpse.ApplicationInsights/GlimpseTelemetryChannel.cs
@@ -140,7 +140,7 @@ namespace Glimpse.ApplicationInsights
             if (item is RequestTelemetry)
             {
                 var request = item as RequestTelemetry;
-                if (request.Url.AbsolutePath != null)
+                if (request.Url != null && request.Url.AbsolutePath != null)
                 {
                     if (request.Url.AbsolutePath.ToLower().EndsWith("glimpse.axd"))
                     {
@@ -173,7 +173,7 @@ namespace Glimpse.ApplicationInsights
             }
 
             // Filter telemetry with empty instrumentation key
-            if (!item.Context.InstrumentationKey.ToString().Equals("00000000-0000-0000-0000-000000000000"))
+            if (item.Context.InstrumentationKey!=null && !item.Context.InstrumentationKey.Equals("00000000-0000-0000-0000-000000000000"))
             {
                 this.ApplicationInsightsChannel.Send(item);
             }


### PR DESCRIPTION
Channel retrieves the channel configured in the ApplicationInsights.config file.
Filters request telemetry to the glimpse handler.
Sends the telemetry to AI if the ikey GUID is not empty.
